### PR TITLE
Refactoring bundler usage.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,3 @@
-source 'http://rubygems.org'
+source :rubygems 
 
-group :runtime do
-  gem 'sinatra',        '>= 0.9.4'
-  gem 'warden',         '>= 0.10.3'
-end
-
-group :test do
-  gem 'rake'
-  gem 'jeweler',        '~> 1.3.0'
-  gem 'bundler',        '~> 0.9.7'
-  gem 'rspec',          '~> 1.2.9', :require => 'spec'
-  gem 'yard',           '>= 0.5.4'
-  gem 'rack-test',      '~> 0.5.0', :require => 'rack/test'
-  gem 'rcov'
-
-  gem 'do_sqlite3',     '~> 0.10.0'
-  gem 'dm-core',        '~> 0.10.1'
-  gem 'bcrypt-ruby',                :require => 'bcrypt'
-  gem 'haml'
-  gem 'rack-flash',     '~> 0.1.1', :require => 'rack-flash'
-end
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,64 @@
+PATH
+  remote: .
+  specs:
+    sinatra_warden (0.3.2)
+      sinatra (>= 0.9.4)
+      warden (>= 0.10.3)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    addressable (2.2.2)
+    bcrypt-ruby (2.1.2)
+    data_objects (0.10.2)
+      addressable (~> 2.1)
+    dm-core (1.0.2)
+      addressable (~> 2.2)
+      extlib (~> 0.9.15)
+    dm-do-adapter (1.0.2)
+      data_objects (~> 0.10.2)
+      dm-core (~> 1.0.2)
+    dm-migrations (1.0.2)
+      dm-core (~> 1.0.2)
+    dm-sqlite-adapter (1.0.2)
+      dm-do-adapter (~> 1.0.2)
+      do_sqlite3 (~> 0.10.2)
+    do_sqlite3 (0.10.2)
+      data_objects (= 0.10.2)
+    extlib (0.9.15)
+    haml (3.0.23)
+    rack (1.2.1)
+    rack-flash (0.1.1)
+      rack
+    rack-test (0.5.6)
+      rack (>= 1.0)
+    rake (0.8.7)
+    rcov (0.9.9)
+    rspec (1.2.9)
+    sinatra (1.1.0)
+      rack (~> 1.1)
+      tilt (~> 1.1)
+    tilt (1.1)
+    warden (1.0.1)
+      rack (>= 1.0.0)
+    yard (0.6.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bcrypt-ruby
+  dm-core (~> 1.0)
+  dm-migrations
+  dm-sqlite-adapter
+  do_sqlite3 (~> 0.10.0)
+  haml
+  rack-flash (~> 0.1.1)
+  rack-test (~> 0.5.0)
+  rake
+  rcov
+  rspec (~> 1.2.9)
+  sinatra (>= 0.9.4)
+  sinatra_warden!
+  warden (>= 0.10.3)
+  yard (>= 0.5.4)

--- a/Rakefile
+++ b/Rakefile
@@ -1,26 +1,6 @@
-require 'rake'
 require 'bundler'
-
-begin
-  require 'jeweler'
-  Jeweler::Tasks.new do |gem|
-    gem.name = "sinatra_warden"
-    gem.summary = %Q{authentication system for using warden with sinatra}
-    gem.description = %Q{basic helpers and authentication methods for using warden with sinatra also providing some hooks into Rack::Flash}
-    gem.email = "justin.smestad@gmail.com"
-    gem.homepage = "http://github.com/jsmestad/sinatra_warden"
-    gem.authors = ["Justin Smestad", "Daniel Neighman"]
-
-    bundle = Bundler::Definition.from_gemfile('Gemfile')
-    bundle.dependencies.each do |dep|
-      next unless dep.groups.include?(:runtime)
-      gem.add_dependency(dep.name, dep.version_requirements.to_s)
-    end
-  end
-  Jeweler::GemcutterTasks.new
-rescue LoadError
-  puts "Jeweler (or a dependency) not available. Install it with: sudo gem install jeweler"
-end
+Bundler::GemHelper.install_tasks
+Bundler.setup :development
 
 require 'spec/rake/spectask'
 Spec::Rake::SpecTask.new(:spec) do |spec|

--- a/lib/sinatra_warden/sinatra.rb
+++ b/lib/sinatra_warden/sinatra.rb
@@ -1,3 +1,4 @@
+require 'sinatra'
 module Sinatra
   module Warden
     module Helpers

--- a/lib/sinatra_warden/version.rb
+++ b/lib/sinatra_warden/version.rb
@@ -1,0 +1,3 @@
+module SinatraWarden
+  VERSION = "0.3.2"
+end

--- a/sinatra_warden.gemspec
+++ b/sinatra_warden.gemspec
@@ -3,65 +3,40 @@
 # Instead, edit Jeweler::Tasks in Rakefile, and run the gemspec command
 # -*- encoding: utf-8 -*-
 
+require File.expand_path("../lib/sinatra_warden/version", __FILE__)
+
 Gem::Specification.new do |s|
   s.name = %q{sinatra_warden}
-  s.version = "0.3.1"
-
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.version     = SinatraWarden::VERSION
+  s.platform    = Gem::Platform::RUBY
   s.authors = ["Justin Smestad", "Daniel Neighman"]
-  s.date = %q{2010-07-15}
-  s.description = %q{basic helpers and authentication methods for using warden with sinatra also providing some hooks into Rack::Flash}
   s.email = %q{justin.smestad@gmail.com}
-  s.extra_rdoc_files = [
-    "LICENSE",
-     "README.rdoc"
-  ]
-  s.files = [
-    ".document",
-     ".gitignore",
-     "Gemfile",
-     "LICENSE",
-     "README.rdoc",
-     "Rakefile",
-     "VERSION",
-     "lib/sinatra_warden.rb",
-     "lib/sinatra_warden/sinatra.rb",
-     "sinatra_warden.gemspec",
-     "spec/fixtures/basic_strategy.rb",
-     "spec/fixtures/testing_login.rb",
-     "spec/fixtures/user.rb",
-     "spec/fixtures/views/login.haml",
-     "spec/sinatra_warden_spec.rb",
-     "spec/spec.opts",
-     "spec/spec_helper.rb"
-  ]
-  s.homepage = %q{http://github.com/jsmestad/sinatra_warden}
-  s.rdoc_options = ["--charset=UTF-8"]
-  s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.3.7}
   s.summary = %q{authentication system for using warden with sinatra}
-  s.test_files = [
-    "spec/fixtures/basic_strategy.rb",
-     "spec/fixtures/testing_login.rb",
-     "spec/fixtures/user.rb",
-     "spec/sinatra_warden_spec.rb",
-     "spec/spec_helper.rb"
-  ]
+  s.description = %q{basic helpers and authentication methods for using warden with sinatra also providing some hooks into Rack::Flash}
 
-  if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
-    s.specification_version = 3
+  s.required_rubygems_version = ">= 1.3.6"
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<sinatra>, [">= 0.9.4"])
-      s.add_runtime_dependency(%q<warden>, [">= 0.10.3"])
-    else
-      s.add_dependency(%q<sinatra>, [">= 0.9.4"])
-      s.add_dependency(%q<warden>, [">= 0.10.3"])
-    end
-  else
-    s.add_dependency(%q<sinatra>, [">= 0.9.4"])
-    s.add_dependency(%q<warden>, [">= 0.10.3"])
-  end
+  s.rdoc_options = ["--charset=UTF-8"]
+  
+  s.add_dependency 'sinatra', '>= 0.9.4'
+  s.add_dependency 'warden',  '>= 0.10.3'
+  
+  s.add_development_dependency 'rspec', '~> 1.2.9'
+  s.add_development_dependency 'yard', '>= 0.5.4'
+  s.add_development_dependency 'rack-test', '~> 0.5.0'
+  s.add_development_dependency 'rcov'
+  s.add_development_dependency 'rake'
+
+  s.add_development_dependency 'do_sqlite3', '~> 0.10.0'
+  s.add_development_dependency 'dm-core', '~> 1.0'
+  s.add_development_dependency 'dm-sqlite-adapter'
+  s.add_development_dependency 'dm-migrations'
+  s.add_development_dependency 'bcrypt-ruby'
+  s.add_development_dependency 'haml'
+  s.add_development_dependency 'rack-flash', '~> 0.1.1'
+  
+  s.files        = `git ls-files`.split("\n")
+  s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
+  s.require_path = 'lib'
 end
 

--- a/spec/fixtures/testing_login.rb
+++ b/spec/fixtures/testing_login.rb
@@ -1,3 +1,6 @@
+require 'rack/flash'
+require "rack/test"
+
 Warden::Strategies.add(:password) do
   def valid?
     # params['email'] && params['password']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-Bundler.require(:default, :runtime, :test)
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
@@ -7,7 +6,8 @@ ENV['RACK_ENV'] ||= 'test'
 require 'sinatra_warden'
 require 'spec'
 require 'spec/autorun'
-
+require 'dm-core'
+require 'dm-migrations'
 DataMapper.setup(:default, 'sqlite3::memory:')
 
 %w(fixtures support).each do |path|


### PR DESCRIPTION
I have made small modification to the way you where using bundler. In the Gemfile file you can specify to bundler to use the gemspecs directly. This way we don't have to double the gem definitions in the Gemfile file.
http://jeffkreeftmeijer.com/2010/bundler-because-your-gems-depend-on-gems-too/

I have also removed the jeweler dependency (maybe I went too far), since it's not really necessary anymore.
http://jeffkreeftmeijer.com/2010/be-awesome-write-your-gemspec-yourself/

I have also included the Gemfile.lock file so that next time someone wants to contribute he will have exactly the same configuration that the gem was tested against.

Hope that you will be interested into those changes.

Best regards
